### PR TITLE
Request Timeout and tweak to request throttling

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -227,12 +227,12 @@ function pauseQueues(duration) {
  * @param {number} waitTime Miliseconds elapsed between start and end of request
  */
 function throttleQueues(err, resp, waitTime) {
-    if (err || (resp && resp.statusCode >= 400)) {
+    if (err || (resp && resp.statusCode >= 500)) {
         if (internals.pauseTime > 0) {
             internals.pauseTime *= 2;
         }
         internals.pauseTime = Math.max(internals.pauseTime, 6e4);
-    } else if (waitTime >= 3000) {
+    } else if (waitTime >= 3000 || (resp && resp.statusCode >= 400)) {
         if (internals.pauseTime > 0) {
             internals.pauseTime *= 2;
         }

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -15,6 +15,7 @@ const request = require('request'),
 const defaults = {
         rejectUnauthorized: false,
         jar: request.jar(),
+        timeout: 15000,
         headers: {
             'X-Requested-With': 'XMLHttpRequest',
             'User-Agent': 'SockBot/' + packageInfo.version + ' (' + packageInfo.releaseName +


### PR DESCRIPTION
add Timeout to request.defaults to prevent extreme waits for responses

Shorten request throttle back off on client errors (4xx http status)