### PR TITLE
Fix cross-document links.

### DIFF
--- a/docs/Development/plugin creation.md
+++ b/docs/Development/plugin creation.md
@@ -51,9 +51,9 @@ notifications and other events.
 This parameter will be a [browser] that is set up to communicate with Discourse. At the time of the 
 prepare() call the browser will not have yet authenticated with discourse.
 
-[EventEmitter]: ../api/external/events#module_SockEvents
-[browser]: ../api/lib/browser#module_browser
-[configuration]: ../api/lib/config
+[EventEmitter]: ../api/external/events.md#module_SockEvents
+[browser]: ../api/lib/browser.md#module_browser
+[configuration]: ../api/lib/config.md
 
 ### Function `start()`
 

--- a/docs/Plugins/summoner.md
+++ b/docs/Plugins/summoner.md
@@ -23,7 +23,7 @@ For example, if the bot is summoned by user @joeRandom and the reply
 the value of the `username` key in the post, resulting in the reply text of: 
 `'@joeRandom has summoned me, and so I appear.'`
 
-[post]: ../api/external/posts/#external.module_posts.Post
+[post]: ../api/external/posts.md#external.module_posts.Post
 
 ## Configuration Options
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ Core configuration options are fixed and can be found described in the API docum
 Plugin configuration options are determined by the individual plugins and will vary from plugin to plugin;
 consult each plugins' documentation for more details.
 
-[defaultConfig]: api/config/#defaultConfig
+[defaultConfig]: ./api/lib/config.md#defaultConfig
 
 ## Core Configuration
 Core configuration sets options for the entire bot, such as username/password to login as and what forum to 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,7 +87,7 @@ plugins:
   echo: true
 ```
 
-[config]: ./configuration/
+[config]: ./configuration.md
 
 ## Running the bot
 


### PR DESCRIPTION
Update internal cross-document links in the docs/ folder to point
at the correct objects.  Documents in docs/api were ignored, as
they appear to be automatically generated.