### PR TITLE
Refactor `help` command

### DIFF
--- a/docs/api/lib/commands.md
+++ b/docs/api/lib/commands.md
@@ -111,7 +111,7 @@ Shut the bot up until manually restarted
 
 <a name="module_commands..cmdHelp"></a>
 ### commands~cmdHelp(command)
-Reply with help test top the command !help
+Reply with help to the command !help
 
 **Kind**: inner method of <code>[commands](#module_commands)</code>  
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -197,7 +197,7 @@ function cmdShutUp(command) {
 }
 
 /**
- * Reply with help test top the command !help
+ * Reply with help to the command !help
  *
  * @param {command} command help command
  */

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -144,10 +144,36 @@ exports.parseCommands = function parseCommands(post, topic, callback) {
  * @returns {string} command list for posting
  */
 function getCommandHelps() {
-    const cmds = Object.keys(internals.commands),
+    const cmds = {},
+        topics = {},
         result = ['Registered commands:'];
-    cmds.sort();
-    cmds.forEach((cmd) => result.push(cmd + ': ' + internals.commands[cmd].help));
+    let keys = {};
+    Object.keys(internals.commands).map((key) => {
+        keys[key] = 1;
+    });
+    Object.keys(internals.helpMessages).map((key) => {
+        keys[key] = 1;
+    });
+    Object.keys(keys).map((key) => {
+        if (internals.commands[key]) {
+            cmds[key] = internals.commands[key].help;
+            if (internals.helpMessages[key]) {
+                cmds[key] += ' *';
+            }
+        } else {
+            topics[key] = 'Extended help topic';
+        }
+    });
+    keys = Object.keys(cmds);
+    keys.sort();
+    keys.forEach((cmd) => result.push(cmd + ': ' + cmds[cmd]));
+    keys = Object.keys(topics);
+    if (keys.length) {
+        result.push('');
+        result.push('Help Topics:');
+        keys.sort();
+        keys.forEach((topic) => result.push(topic + ': ' + topics[topic]));
+    }
     return result.join('\n');
 }
 
@@ -210,13 +236,13 @@ function cmdHelp(command) {
         ext = command.args.join(' ');
     }
     if (ext && internals.helpMessages[ext]) {
-        const txt = 'Extended help for `' + ext + '`\n\n' + internals.helpMessages[ext] +
+        const txt = 'Help topic for `' + ext + '`\n\n' + internals.helpMessages[ext] +
             '\n\nIssue the `help` command without any parameters to see all available commands';
         browser.createPost(command.post.topic_id, command.post.post_number, txt, () => 0);
         return;
     }
-    const help = internals.getCommandHelps() + '\n\nMore details may be available by passing a command name as ' +
-        'the first parameter to `help`';
+    const help = internals.getCommandHelps() + '\n\n\* Help topic available.\n\nIssue the `help` command with an ' +
+        'available help topic as a parameter to read additonal help';
     browser.createPost(command.post.topic_id, command.post.post_number, help, () => 0);
 }
 
@@ -277,6 +303,7 @@ function registerHelp(command, helptext, callback) {
     if (!helptext || typeof helptext !== 'string') {
         return callback(new Error('helptext must be provided'));
     }
+    command = command.toLowerCase();
     if (internals.helpMessages[command]) {
         internals.events.emit('logWarning', 'Overwriting existing extended help for: `' + command + '`!');
     }

--- a/test/lib/commands/statusTest.js
+++ b/test/lib/commands/statusTest.js
@@ -138,7 +138,7 @@ describe('status', () => {
             });
             describe('memoryUsage', () => {
                 it('should return the correct values', () => {
-                    const expected = 'Memory usage: 1 kB free out of 2 kB';
+                    const expected = 'Memory usage: 1 KB free out of 2 KB';
                     sandbox.stub(os, 'freemem', () => 1024);
                     sandbox.stub(os, 'totalmem', () => 2048);
                     expect(status.internals.memoryUsage()).to.be.equal(expected);

--- a/test/plugins/anonymizeTest.js
+++ b/test/plugins/anonymizeTest.js
@@ -121,8 +121,8 @@ describe('anonymize', () => {
             const spy = sandbox.stub(browser, 'createPost'),
                 rawContent = '[quote="SockBot, post:4, topic:3"]Anonymized quote![/quote]Anonymized reply!';
             spy.yields(null, {
-                topic_id: 5,
-                post_number: 6
+                'topic_id': 5,
+                'post_number': 6
             }); //eslint-disable-line camelcase
             anonymize.prepare(undefined, dummyCfg, {
                 onNotification: () => 0,


### PR DESCRIPTION
Help command now indicates which commands have additional help registered and lists help topics that do not correspond to a command.