### PR TITLE
Make local plugin paths predicatble and sane

### DIFF
--- a/SockBot.js
+++ b/SockBot.js
@@ -137,7 +137,7 @@ function doPluginRequire(module, requireIt) {
     try {
         let resolved = './plugins/' + module;
         if (module[0] === '/' || module.substring(0, 2) === './' || module.substring(0, 3) === '../') {
-            resolved = path.resolve(config.basePath, module);
+            resolved = path.posix.resolve(config.basePath, module);
         }
         // Look in plugins first
         return requireIt(resolved);

--- a/SockBot.js
+++ b/SockBot.js
@@ -9,7 +9,8 @@
  */
 
 const async = require('async');
-const EventEmitter = require('events').EventEmitter;
+const EventEmitter = require('events').EventEmitter,
+    path = require('path');
 const config = require('./lib/config'),
     messages = require('./lib/messages'),
     notifications = require('./lib/notifications'),
@@ -134,8 +135,12 @@ exports.stop = function (callback) {
  */
 function doPluginRequire(module, requireIt) {
     try {
+        let resolved = './plugins/' + module;
+        if (module[0] === '/' || module.substring(0, 2) === './' || module.substring(0, 3) === '../') {
+            resolved = path.resolve(config.basePath, module);
+        }
         // Look in plugins first
-        return requireIt('./plugins/' + module);
+        return requireIt(resolved);
     } catch (e) {
         // Error! check if it's ENOENT and try raw module
         if (/^Cannot find module/.test(e.message)) {

--- a/docs/api/lib/config.md
+++ b/docs/api/lib/config.md
@@ -9,6 +9,10 @@
 <dd><p>Current plugin configuration</p>
 <p>Set by internals. Do not edit</p>
 </dd>
+<dt><a href="#basePath">basePath</a> : <code>string</code></dt>
+<dd><p>Base Path of the active config file</p>
+<p>Set by internals. Do not edit</p>
+</dd>
 <dt><a href="#mergeObjects">mergeObjects</a> ⇒ <code>object</code></dt>
 <dd><p>Merge multiple objects into one object</p>
 <p>Later objects override earlier objects</p>
@@ -32,10 +36,10 @@ exposed to allow plugins to call it without <code>require</code>ing <code>utils<
 ## Functions
 
 <dl>
-<dt><a href="#readFile">readFile(path, callback)</a></dt>
+<dt><a href="#readFile">readFile(filePath, callback)</a></dt>
 <dd><p>Read and parse configuration file from disc</p>
 </dd>
-<dt><a href="#loadConfiguration">loadConfiguration(path, callback)</a></dt>
+<dt><a href="#loadConfiguration">loadConfiguration(filePath, callback)</a></dt>
 <dd><p>Load configuration from disc</p>
 </dd>
 </dl>
@@ -59,6 +63,14 @@ Set by internals. Do not edit
 <a name="plugins"></a>
 ## plugins
 Current plugin configuration
+
+Set by internals. Do not edit
+
+**Kind**: global variable  
+**Read only**: true  
+<a name="basePath"></a>
+## basePath : <code>string</code>
+Base Path of the active config file
 
 Set by internals. Do not edit
 
@@ -109,6 +121,7 @@ Default configuration options
         * [.pollMessages](#defaultConfig.core.pollMessages) : <code>boolean</code>
         * [.pollNotifications](#defaultConfig.core.pollNotifications) : <code>boolean</code>
     * [.plugins](#defaultConfig.plugins) : <code>object</code>
+    * [.basePath](#defaultConfig.basePath) : <code>string</code>
 
 <a name="defaultConfig.core"></a>
 ### defaultConfig.core : <code>object</code>
@@ -214,26 +227,31 @@ Plugin configuration.
 See `Plugin Configuration` for details
 
 **Kind**: static property of <code>[defaultConfig](#defaultConfig)</code>  
+<a name="defaultConfig.basePath"></a>
+### defaultConfig.basePath : <code>string</code>
+Base Path of the active config file
+
+**Kind**: static property of <code>[defaultConfig](#defaultConfig)</code>  
 <a name="readFile"></a>
-## readFile(path, callback)
+## readFile(filePath, callback)
 Read and parse configuration file from disc
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| path | <code>string</code> | Path of file to read |
+| filePath | <code>string</code> | Path of file to read |
 | callback | <code>[configComplete](#configComplete)</code> | Completion callback |
 
 <a name="loadConfiguration"></a>
-## loadConfiguration(path, callback)
+## loadConfiguration(filePath, callback)
 Load configuration from disc
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| path | <code>string</code> | Configuration file path |
+| filePath | <code>string</code> | Configuration file path |
 | callback | <code>[configComplete](#configComplete)</code> | Completion callback |
 
 <a name="configComplete"></a>

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,7 @@
 const utils = require('./utils');
 
 const fs = require('fs'),
+    path = require('path'),
     yaml = require('js-yaml');
 
 /**
@@ -117,21 +118,27 @@ const defaultConfig = {
      *
      * @type {object}
      */
-    plugins: {}
+    plugins: {},
+    /**
+     * Base Path of the active config file
+     *
+     * @type {string}
+     */
+    basePath: null
 };
 
 /**
  * Read and parse configuration file from disc
  *
- * @param {string} path Path of file to read
+ * @param {string} filePath Path of file to read
  * @param {configComplete} callback Completion callback
  */
-function readFile(path, callback) {
-    if (!path || typeof path !== 'string') {
+function readFile(filePath, callback) {
+    if (!filePath || typeof filePath !== 'string') {
         callback(new Error('Path must be a string'));
         return;
     }
-    fs.readFile(path, (err, data) => {
+    fs.readFile(filePath, (err, data) => {
         if (err) {
             return callback(err);
         }
@@ -151,11 +158,11 @@ function readFile(path, callback) {
 /**
  * Load configuration from disc
  *
- * @param {string} path Configuration file path
+ * @param {string} filePath Configuration file path
  * @param {configComplete} callback Completion callback
  */
-exports.loadConfiguration = function loadConfiguration(path, callback) {
-    readFile(path, (err, config) => {
+exports.loadConfiguration = function loadConfiguration(filePath, callback) {
+    readFile(filePath, (err, config) => {
         if (err) {
             callback(err);
             return;
@@ -164,6 +171,7 @@ exports.loadConfiguration = function loadConfiguration(path, callback) {
             const cfg = utils.mergeObjects(true, defaultConfig, config);
             exports.core = cfg.core;
             exports.plugins = cfg.plugins;
+            exports.basePath = path.resolve(filePath, '..');
             validateConfiguration();
             callback(null, cfg);
         } catch (e) {
@@ -172,24 +180,21 @@ exports.loadConfiguration = function loadConfiguration(path, callback) {
     });
 };
 
-/* eslint-disable complexity */
-// Unless we want (potentially) hundreds of mini-functions, we should allow the complexity to rise
 function validateConfiguration() {
     const errors = [];
-    if (!exports.core.username || typeof exports.core.username !== 'string' || exports.core.username.length < 1) {
+    if (typeof exports.core.username !== 'string' || exports.core.username.length < 1) {
         errors.push('A valid username must be specified');
     }
-    if (!exports.core.password || typeof exports.core.password !== 'string' || exports.core.password.length < 1) {
+    if (typeof exports.core.password !== 'string' || exports.core.password.length < 1) {
         errors.push('A valid password must be specified');
     }
-    if (!exports.core.owner || typeof exports.core.owner !== 'string' || exports.core.owner.length < 1) {
+    if (typeof exports.core.owner !== 'string' || exports.core.owner.length < 1) {
         errors.push('A valid owner must be specified');
     }
     if (errors.length > 0) {
         throw new Error(errors.join('\n'));
     }
 }
-/* eslint-enable complexity */
 
 /**
  * Configuration Loaded Callback
@@ -220,6 +225,17 @@ exports.core = config.core;
  * @readonly
  */
 exports.plugins = config.plugins;
+
+
+/**
+ * Base Path of the active config file
+ *
+ * Set by internals. Do not edit
+ *
+ * @type {string}
+ * @readonly
+ */
+exports.basePath = config.basePath;
 
 /**
  * Merge multiple objects into one object

--- a/lib/config.js
+++ b/lib/config.js
@@ -171,7 +171,7 @@ exports.loadConfiguration = function loadConfiguration(filePath, callback) {
             const cfg = utils.mergeObjects(true, defaultConfig, config);
             exports.core = cfg.core;
             exports.plugins = cfg.plugins;
-            exports.basePath = path.resolve(filePath, '..');
+            exports.basePath = path.posix.resolve(filePath, '..');
             validateConfiguration();
             callback(null, cfg);
         } catch (e) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,8 +9,8 @@ const async = require('async');
 const config = require('./config');
 
 const internals = {
-        cooldownTimers: {}
-    };
+    cooldownTimers: {}
+};
 
 /**
  * Generate a "good enough" Type 4 UUID.
@@ -114,7 +114,7 @@ function mergeHelper(base, mixin, name, mergeArrays) {
         } else {
             base[name] = mixin[name];
         }
-    } else if (typeof mixin[name] === 'object' && mixin[name]!==null) {
+    } else if (typeof mixin[name] === 'object' && mixin[name] !== null) {
         let newBase = base[name] || {};
         if (Array.isArray(newBase)) {
             newBase = {};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -114,7 +114,7 @@ function mergeHelper(base, mixin, name, mergeArrays) {
         } else {
             base[name] = mixin[name];
         }
-    } else if (typeof mixin[name] === 'object') {
+    } else if (typeof mixin[name] === 'object' && mixin[name]!==null) {
         let newBase = base[name] || {};
         if (Array.isArray(newBase)) {
             newBase = {};

--- a/test/lib/configTest.js
+++ b/test/lib/configTest.js
@@ -287,8 +287,8 @@ describe('config', () => {
             const cwd = process.cwd();
             [
                 ['./config', cwd],
-                ['../foo/config.js', path.resolve(cwd, '../foo')],
-                ['./foo/config.js', path.resolve(cwd, 'foo')],
+                ['../foo/config.js', path.posix.resolve(cwd, '../foo')],
+                ['./foo/config.js', path.posix.resolve(cwd, 'foo')],
                 ['/foo/bar/baz/config.js', '/foo/bar/baz'],
                 ['/config.js', '/']
             ].forEach((cfg) => {

--- a/test/lib/utilsTest.js
+++ b/test/lib/utilsTest.js
@@ -158,6 +158,14 @@ describe('utils', () => {
             expect(() => mergeInner(base, mixin)).to.not.throw();
             base.should.deep.equal(mixin);
         });
+        it('should accept null mixin key value', () => {
+            const mixin = {
+                    a: null
+                },
+                base = {};
+            expect(() => mergeInner(base, mixin)).to.not.throw();
+            base.should.deep.equal(mixin);
+        });
         it('should accept empty mixin object', () => {
             const base = {
                     a: 1


### PR DESCRIPTION
local plugins are now parsed as relative to the config file location on disck, not wherever SockBot happens to be installed.

This will make config files for non-core plugins much more managable.

Resolves #271 