### PR TITLE
refactor(Promises): Promises now always reject when Errors

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -542,10 +542,10 @@ exports.bindCommands = function bindCommands(forum) {
                     forbiddenMsg = 'not allowed by the active forum provider.';
                 checkAvailable(shadowHandlers, cmd, 'log', shadowingMsg);
                 if (!checkAvailable(handlers, cmd, 'error', conflictMsg)) {
-                    return reject('E_ALREADY_REGISTERED');
+                    return reject(new Error('E_ALREADY_REGISTERED'));
                 }
                 if (!checkAvailable(forbiddenCmds, cmd, 'error', forbiddenMsg)) {
-                    return reject('E_FORBIDDEN_COMMAND');
+                    return reject(new Error('E_FORBIDDEN_COMMAND'));
                 }
                 handlers[cmd] = {
                     commandText: command,
@@ -575,10 +575,10 @@ exports.bindCommands = function bindCommands(forum) {
                     forbiddenMsg = 'not allowed by the active forum provider.';
                 checkAvailable(handlers, cmd, 'log', shadowedMsg);
                 if (!checkAvailable(shadowHandlers, cmd, 'error', shadowConflict)) {
-                    return reject('E_ALREADY_REGISTERED');
+                    return reject(new Error('E_ALREADY_REGISTERED'));
                 }
                 if (!checkAvailable(forbiddenCmds, cmd, 'error', forbiddenMsg)) {
-                    return reject('E_FORBIDDEN_COMMAND');
+                    return reject(new Error('E_FORBIDDEN_COMMAND'));
                 }
                 shadowHandlers[cmd] = handler;
                 return resolve(this);

--- a/providers/nodebb/chat.js
+++ b/providers/nodebb/chat.js
@@ -427,7 +427,7 @@ exports.bindChat = function bindChat(forum) {
      */
     function handleChat(payload) {
         if (!payload.message) {
-            return Promise.reject('Event payload did not include chat message');
+            return Promise.reject(new Error('Event payload did not include chat message'));
         }
         const message = ChatRoom.Message.parse(payload.message);
 

--- a/providers/nodebb/index.js
+++ b/providers/nodebb/index.js
@@ -179,6 +179,9 @@ class Forum extends EventEmitter {
             }, (err, _, data) => {
                 if (err) {
                     debug('failed configuration fetch for CSRF token');
+                    if (!(err instanceof Error)) {
+                        err = new Error(err);
+                    }
                     return reject(err);
                 }
                 try {
@@ -222,10 +225,16 @@ class Forum extends EventEmitter {
                 }, (loginError, response, reason) => {
                     if (loginError) {
                         debug(`Login failed for reason: ${loginError}`);
+                        if (!(loginError instanceof Error)) {
+                            loginError = new Error(loginError);
+                        }
                         return reject(loginError);
                     }
                     if (response.statusCode >= 400) {
                         debug(`Login failed for reason: ${reason}`);
+                        if (!(reason instanceof Error)) {
+                            reason = new Error(reason);
+                        }
                         return reject(reason);
                     }
                     debug('complete post login data');
@@ -330,13 +339,13 @@ class Forum extends EventEmitter {
             }
             const plugin = fn(this, pluginConfig);
             if (typeof plugin !== 'object') {
-                return reject('[[invalid_plugin:no_plugin_object]]');
+                return reject(new Error('[[invalid_plugin:no_plugin_object]]'));
             }
             if (typeof plugin.activate !== 'function') {
-                return reject('[[invalid_plugin:no_activate_function]]');
+                return reject(new Error('[[invalid_plugin:no_activate_function]]'));
             }
             if (typeof plugin.deactivate !== 'function') {
-                return reject('[[invalid_plugin:no_deactivate_function]]');
+                return reject(new Error('[[invalid_plugin:no_deactivate_function]]'));
             }
             this._plugins.push(plugin);
             return resolve();
@@ -400,10 +409,13 @@ class Forum extends EventEmitter {
         return new Promise((resolve, reject) => {
             args.push(function continuation(err) {
                 if (err) {
+                    if (!(err instanceof Error)) {
+                        err = new Error(err);
+                    }
                     return reject(err);
                 }
                 const results = Array.prototype.slice.call(arguments);
-                results.shift();
+                results.shift(); // Shift off the `err` argument
                 if (results.length < 2) {
                     return resolve(results[0]);
                 }

--- a/providers/nodebb/index.js
+++ b/providers/nodebb/index.js
@@ -205,6 +205,12 @@ class Forum extends EventEmitter {
      * @fulfill {Forum} Logged in forum
      */
     login() {
+        const errorify = (err) => {
+            if (!(err instanceof Error)) {
+                err = new Error(err);
+            }
+            return err;
+        };
         return this._getConfig()
             .then((config) => new Promise((resolve, reject) => {
                 this._verifyCookies();
@@ -225,17 +231,11 @@ class Forum extends EventEmitter {
                 }, (loginError, response, reason) => {
                     if (loginError) {
                         debug(`Login failed for reason: ${loginError}`);
-                        if (!(loginError instanceof Error)) {
-                            loginError = new Error(loginError);
-                        }
-                        return reject(loginError);
+                        return reject(errorify(loginError));
                     }
                     if (response.statusCode >= 400) {
                         debug(`Login failed for reason: ${reason}`);
-                        if (!(reason instanceof Error)) {
-                            reason = new Error(reason);
-                        }
-                        return reject(reason);
+                        return reject(errorify(reason));
                     }
                     debug('complete post login data');
                     return resolve();

--- a/test/providers/nodebb/indexTest.js
+++ b/test/providers/nodebb/indexTest.js
@@ -331,7 +331,15 @@ describe('providers/nodebb', () => {
         });
         it('should reject on bad request response', () => {
             request.get.yields(new Error('bad'));
-            return forum._getConfig().should.reject;
+            return forum._getConfig().should.be.rejectedWith('bad');
+        });
+        it('should reject with Error on bad request response (string version)', () => {
+            request.get.yields('bad');
+            return forum._getConfig().should.be.rejectedWith(Error);
+        });
+        it('should reject with Error on bad request response (Error version)', () => {
+            request.get.yields(new Error('bad'));
+            return forum._getConfig().should.be.rejectedWith(Error);
         });
         it('should reject on bad JSON response', () => {
             request.get.yields(null, null, '{"foo":"bar');
@@ -441,18 +449,46 @@ describe('providers/nodebb', () => {
             return forum.login().should.become(forum);
         });
         it('should reject when _getConfig rejects', () => {
+            forum._getConfig.rejects(new Error('bad'));
+            return forum.login().should.be.rejectedWith('bad');
+        });
+        it('should reject with an Error when _getConfig rejects with string', () => {
             forum._getConfig.rejects('bad');
-            return forum.login().should.be.rejected;
+            return forum.login().should.be.rejectedWith(Error);
+        });
+        it('should reject with an Error when _getConfig rejects with Error', () => {
+            forum._getConfig.rejects(new Error('bad'));
+            return forum.login().should.be.rejectedWith(Error);
         });
         it('should reject when request.post fails', () => {
             request.post.yields('bad');
-            return forum.login().should.be.rejected;
+            return forum.login().should.be.rejectedWith('bad');
+        });
+        it('should reject with an Error when request.post rejects with string', () => {
+            request.post.yields('bad');
+            return forum.login().should.be.rejectedWith(Error);
+        });
+        it('should reject with an Error when request.post rejects with Error', () => {
+            request.post.yields(new Error('bad'));
+            return forum.login().should.be.rejectedWith(Error);
         });
         it('should reject when request.post yields 4xx status code', () => {
             request.post.yields(null, {
                 statusCode: 403
             }, 'bad');
-            return forum.login().should.be.rejected;
+            return forum.login().should.be.rejectedWith('bad');
+        });
+        it('should reject with Error when request.post yields 4xx status code', () => {
+            request.post.yields(null, {
+                statusCode: 403
+            }, 'bad');
+            return forum.login().should.be.rejectedWith(Error);
+        });
+        it('should reject with Error when request.post yields 4xx status code (2)', () => {
+            request.post.yields(null, {
+                statusCode: 403
+            }, new Error('bad'));
+            return forum.login().should.be.rejectedWith(Error);
         });
     });
     describe('connectWebsocket()', () => {
@@ -867,7 +903,15 @@ describe('providers/nodebb', () => {
         });
         it('should reject when websocket errors', () => {
             forum.socket.emit.yields('bad');
-            return forum._emit().should.be.rejected;
+            return forum._emit().should.be.rejectedWith('bad');
+        });
+        it('should reject with Error when websocket errors with string', () => {
+            forum.socket.emit.yields('bad');
+            return forum._emit().should.be.rejectedWith(Error);
+        });
+        it('should reject with Error when websocket errors with Error', () => {
+            forum.socket.emit.yields(new Error('bad'));
+            return forum._emit().should.be.rejectedWith(Error);
         });
     });
     describe('fetchObject', () => {


### PR DESCRIPTION
When rejecting all Promises generated by SockBot reject with an Error, instead of a string.

Resolves #350