### PR TITLE
chore(ci): Update version under test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: node_js
 node_js:
 - 'node'
-- '4.3'
-- '4.4'
-- '5'
-- '6.1'
+- '4'
 - '6.2'
+- '6.3'
 branches:
   except:
     - /^(?i:v)\d+[.]\d+[.]\d+$/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
     - nodejs_version: '6'
-    - nodejs_version: '5'
     - nodejs_version: '4'
 platform:
   - x64


### PR DESCRIPTION
Remove all but most revent version of nodejs 4 LTS. Remove no longer supported nodejs 5. Update to
only testing two latest releases of current stable nodejs 6.