### PR TITLE
fix(Commands): Fix for images being seen as commands

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -637,7 +637,7 @@ exports.bindCommands = function bindCommands(forum) {
             args.shift();
             commandText = args.shift();
             mention = true;
-        } else if (/^!\S{3,}(\s|$)/.test(line)) {
+        } else if (/^!\w\S{2,}(\s|$)/.test(line)) {
             args = line.split(/\s+/);
             commandText = args.shift().substring(1);
             mention = false;

--- a/test/lib/commandsTest.js
+++ b/test/lib/commandsTest.js
@@ -128,6 +128,9 @@ describe('lib/config', () => {
             it('should not match really short command', () => {
                 expect(parseLine('!c text stuff')).to.equal(null);
             });
+            it('should not match non-letters after !', () => {
+                expect(parseLine('![0_1481227127790_upload.png]')).to.equal(null);
+            });
             it('should match bare command', () => {
                 parseLine('!help').command.should.equal('help');
             });


### PR DESCRIPTION
Commands must now begin with a letter, number, or underscore, though they may contain any character

after that.

Breaking Change: May invalidate previously working commands.