### PR TITLE
Fix GitHub checkout reference

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 version.js export-subst
 *.js       eol=lf
+
+package.config ident

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 version.js export-subst
 *.js       eol=lf
 
-package.config ident
+package.json ident

--- a/docs/api/lib/app.md
+++ b/docs/api/lib/app.md
@@ -2,7 +2,7 @@
 
 <dl>
 <dt><a href="#getVersion">getVersion()</a> ⇒ <code>string</code></dt>
-<dd><p>Get current version information, using latest commit sha1 as a fallback if detected version is semantic release 
+<dd><p>Get current version information, using latest commit sha1 as a fallback if detected version is semantic release
 placeholder.</p>
 </dd>
 <dt><a href="#getUserAgent">getUserAgent(cfg, provider)</a> ⇒ <code>string</code></dt>
@@ -31,7 +31,7 @@ placeholder.</p>
 <a name="getVersion"></a>
 
 ## getVersion() ⇒ <code>string</code>
-Get current version information, using latest commit sha1 as a fallback if detected version is semantic release 
+Get current version information, using latest commit sha1 as a fallback if detected version is semantic release
 placeholder.
 
 **Kind**: global function  

--- a/docs/api/lib/app.md
+++ b/docs/api/lib/app.md
@@ -1,0 +1,124 @@
+## Functions
+
+<dl>
+<dt><a href="#getVersion">getVersion()</a> ⇒ <code>string</code></dt>
+<dd><p>Get current version information, using latest commit sha1 as a fallback if detected version is semantic release 
+placeholder.</p>
+</dd>
+<dt><a href="#getUserAgent">getUserAgent(cfg, provider)</a> ⇒ <code>string</code></dt>
+<dd><p>Construct a useragent for sockbot to use</p>
+</dd>
+<dt><a href="#_buildMessage">_buildMessage(args)</a> ⇒ <code>string</code></dt>
+<dd><p>Construct a stringified message to log</p>
+</dd>
+<dt><a href="#log">log(...message)</a></dt>
+<dd><p>Log a message to stdout</p>
+</dd>
+<dt><a href="#error">error(...message)</a></dt>
+<dd><p>Log a message to stderr</p>
+</dd>
+<dt><a href="#relativeRequire">relativeRequire(relativePath, module, requireIt)</a> ⇒ <code>object</code> | <code>function</code></dt>
+<dd><p>Load a module relative to a local path, or relative to loaded config file</p>
+</dd>
+<dt><a href="#loadPlugins">loadPlugins(forumInstance, botConfig)</a> ⇒ <code>Promise</code></dt>
+<dd><p>Load plugins for forum instance</p>
+</dd>
+<dt><a href="#activateConfig">activateConfig(botConfig)</a> ⇒ <code>Promise</code></dt>
+<dd><p>Activate a loaded configuration.</p>
+</dd>
+</dl>
+
+<a name="getVersion"></a>
+
+## getVersion() ⇒ <code>string</code>
+Get current version information, using latest commit sha1 as a fallback if detected version is semantic release 
+placeholder.
+
+**Kind**: global function  
+**Returns**: <code>string</code> - Version information  
+<a name="getUserAgent"></a>
+
+## getUserAgent(cfg, provider) ⇒ <code>string</code>
+Construct a useragent for sockbot to use
+
+**Kind**: global function  
+**Returns**: <code>string</code> - User-Agent to use for a forum instance  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| cfg | <code>object</code> | Instance Configuration to construct User Agent for |
+| provider | <code>Forum</code> | Forum Provider class to construct User Agent for |
+
+<a name="_buildMessage"></a>
+
+## _buildMessage(args) ⇒ <code>string</code>
+Construct a stringified message to log
+
+**Kind**: global function  
+**Returns**: <code>string</code> - stringified message  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| args | <code>Array.&lt;\*&gt;</code> | Item to stringify and log |
+
+<a name="log"></a>
+
+## log(...message)
+Log a message to stdout
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...message | <code>\*</code> | Message to log to stdout |
+
+<a name="error"></a>
+
+## error(...message)
+Log a message to stderr
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...message | <code>\*</code> | Message to log to stderr |
+
+<a name="relativeRequire"></a>
+
+## relativeRequire(relativePath, module, requireIt) ⇒ <code>object</code> &#124; <code>function</code>
+Load a module relative to a local path, or relative to loaded config file
+
+**Kind**: global function  
+**Returns**: <code>object</code> &#124; <code>function</code> - Loaded module  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| relativePath | <code>string</code> | Local path to use |
+| module | <code>string</code> | Module to load |
+| requireIt | <code>function</code> | Function to use to load module |
+
+<a name="loadPlugins"></a>
+
+## loadPlugins(forumInstance, botConfig) ⇒ <code>Promise</code>
+Load plugins for forum instance
+
+**Kind**: global function  
+**Returns**: <code>Promise</code> - Resolves when plugins have been loaded  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| forumInstance | <code>Provider</code> | Provider instance to load plugins into |
+| botConfig | <code>object</code> | Bot configuration to load plugins with |
+
+<a name="activateConfig"></a>
+
+## activateConfig(botConfig) ⇒ <code>Promise</code>
+Activate a loaded configuration.
+
+**Kind**: global function  
+**Returns**: <code>Promise</code> - Resolves when configuration is fully activated  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| botConfig | <code>object</code> | Configuration to activate |
+

--- a/lib/app.js
+++ b/lib/app.js
@@ -11,9 +11,9 @@ const packageInfo = require('../package.json'),
 const debug = require('debug')('sockbot');
 
 /**
- * Get current version information, using latest commit sha1 as a fallback if detected version is semantic release 
+ * Get current version information, using latest commit sha1 as a fallback if detected version is semantic release
  * placeholder.
- * 
+ *
  * @returns {string} Version information
  */
 exports.getVersion = function getVersion() {

--- a/lib/app.js
+++ b/lib/app.js
@@ -11,6 +11,29 @@ const packageInfo = require('../package.json'),
 const debug = require('debug')('sockbot');
 
 /**
+ * Get current version information, using latest commit sha1 as a fallback if detected version is semantic release 
+ * placeholder.
+ * 
+ * @returns {string} Version information
+ */
+exports.getVersion = function getVersion() {
+    if (packageInfo.version !== '0.0.0-semantic-release') {
+        return packageInfo.version;
+    }
+    const parser = /\$Id: (\S+)\$/;
+    if (packageInfo.latestCommit) {
+        const parsed = parser.exec(packageInfo.latestCommit);
+        if (parsed && parsed[1]) {
+            return parsed[1];
+        }
+        if (packageInfo.latestCommit !== '$Id$') {
+            return packageInfo.latestCommit;
+        }
+    }
+    return '[Unknown Version]';
+};
+
+/**
  * Construct a useragent for sockbot to use
  *
  * @param {object} cfg Instance Configuration to construct User Agent for
@@ -18,7 +41,7 @@ const debug = require('debug')('sockbot');
  * @returns {string} User-Agent to use for a forum instance
  */
 exports.getUserAgent = function getUserAgent(cfg, provider) {
-    const ua = `${packageInfo.name}/${packageInfo.version} ` +
+    const ua = `${packageInfo.name}/${exports.getVersion()} ` +
         `(${process.platform} ${process.arch}) ` +
         `(nodejs v${process.versions.node}) ` +
         `(v8 v${process.versions.v8}) ` +
@@ -168,7 +191,7 @@ if (require.main === module) {
         .usage('Usage: $0 <cfgFile>')
         .demand(1, 1, 'A valid configuration file must be provided')
         .argv;
-    exports.log(`Starting Sockbot ${packageInfo.version} - ${packageInfo.releaseName}`);
+    exports.log(`Starting Sockbot ${exports.getVersion()}`);
     config.load(argv._[0])
         .then((cfg) => {
             exports.log(`Loaded configuration file: ${argv._[0]}`);

--- a/lib/app.js
+++ b/lib/app.js
@@ -20,7 +20,7 @@ exports.getVersion = function getVersion() {
     if (packageInfo.version !== '0.0.0-semantic-release') {
         return packageInfo.version;
     }
-    const parser = /\$Id: (\S+)\$/;
+    const parser = /\$Id: (\S+) \$/;
     if (packageInfo.latestCommit) {
         const parsed = parser.exec(packageInfo.latestCommit);
         if (parsed && parsed[1]) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "sockbot",
+  "latestCommit": "$Id$",
   "version": "0.0.0-semantic-release",
   "description": "A sockpuppet bot to use on http://what.thedailywtf.com.",
   "repository": {

--- a/test/lib/appTest.js
+++ b/test/lib/appTest.js
@@ -421,8 +421,13 @@ describe('lib/app', () => {
         let username = null,
             owner = null,
             ua = null,
-            provider = null;
+            provider = null,
+            sandbox = null,
+            version = null;
         beforeEach(() => {
+            version = `ver$${Math.random()}$`;
+            sandbox = sinon.sandbox.create();
+            sandbox.stub(testModule, 'getVersion').returns(version);
             username = `username${Math.random()}`;
             owner = `owner${Math.random()}`;
             provider = {};
@@ -433,6 +438,7 @@ describe('lib/app', () => {
                 }
             }, provider);
         });
+        afterEach(() => sandbox.restore());
         it('should return a string', () => {
             testModule.getUserAgent({
                 core: {}
@@ -454,7 +460,7 @@ describe('lib/app', () => {
             }).should.endWith(expected);
         });
         it('should startWith package name/version', () => {
-            ua.indexOf(`${packageInfo.name}/${packageInfo.version}`).should.equal(0);
+            ua.indexOf(`${packageInfo.name}/${version}`).should.equal(0);
         });
         it('should contain OS platform/architecture', () => {
             ua.indexOf(`${process.platform} ${process.arch}`).should.be.greaterThan(0);
@@ -500,6 +506,34 @@ describe('lib/app', () => {
             testModule.ponyError(undefined, new Error(message));
             const lines = testModule.error.firstCall.args[0].split('\n');
             lines[lines.length - 1].should.endWith(message);
+        });
+    });
+    describe('getVersion()', () => {
+        const sha = '33d24d7c8f7f8cf320abb39425375d74d280f3e3';
+        beforeEach(() => {
+            packageInfo.version = '0.0.0-semantic-release'; // Restore placeholder version
+            packageInfo.latestCommit = `$Id: ${sha}$`;
+        });
+        it('should provide version when version is not semantic-release placeholder', () => {
+            const version = `${Math.random() * 20}.${Math.random() * 20}`;
+            packageInfo.version = version;
+            testModule.getVersion().should.equal(version);
+        });
+        it('should provide latestCommit sha when version is placeholder and format is correct', () => {
+            testModule.getVersion().should.equal(sha);
+        });
+        it('should provide latestCommit when version is place holder and format is weird', () => {
+            const version = `I LIKE ${Math.ceil(Math.random() * 1000)}FISH`;
+            packageInfo.latestCommit = version;
+            testModule.getVersion().should.equal(version);
+        });
+        it('should provide unknown version when version is placeholder and latestCommit is placeholder', () => {
+            packageInfo.latestCommit = '$Id$';
+            testModule.getVersion().should.equal('[Unknown Version]');
+        });
+        it('should provide unknown version when version is placeholder and latestCommit is missing', () => {
+            packageInfo.latestCommit = undefined;
+            testModule.getVersion().should.equal('[Unknown Version]');
         });
     });
 });

--- a/test/lib/appTest.js
+++ b/test/lib/appTest.js
@@ -512,7 +512,7 @@ describe('lib/app', () => {
         const sha = '33d24d7c8f7f8cf320abb39425375d74d280f3e3';
         beforeEach(() => {
             packageInfo.version = '0.0.0-semantic-release'; // Restore placeholder version
-            packageInfo.latestCommit = `$Id: ${sha}$`;
+            packageInfo.latestCommit = `$Id: ${sha} $`;
         });
         it('should provide version when version is not semantic-release placeholder', () => {
             const version = `${Math.random() * 20}.${Math.random() * 20}`;


### PR DESCRIPTION
Fixes the release name so that github checkout versions are identifiable

package.json now exposes latestCommit as an ident field. on github checkout it will be transformed to contain a string in the form of: `$Id: 612c4e0b2ab2d70d17acd78801aae6f4b9445fd8 $` this will be parsed and used as the version number if the package version equals the semantic-release placeholder of `0.0.0-semantic-release`

if the package version is this placeholder version and latestCommit does not match the expected ident format the latestCommit string will be used as-is. Should the latestCommit field fail to contain a value the ultimate fallback version will be `[Unknown Version]`