### PR TITLE
chore: pin request to 2.83.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "debug": "^3.0.0",
     "js-yaml": "^3.6.0",
-    "request": "^2.81.0",
+    "request": "2.83.0",
     "sanitize-html": "^1.13.0",
     "socket.io-client": "^2.0.0",
     "string": "^3.3.1",


### PR DESCRIPTION
They dropped support for Node 4 and we haven't. 